### PR TITLE
Fix blank screen in WP 5.0 by adding the wp-editor dependency

### DIFF
--- a/src/init.php
+++ b/src/init.php
@@ -47,7 +47,7 @@ function simple_metabox_cgb_editor_assets() {
 	wp_enqueue_script(
 		'simple_metabox-cgb-block-js', // Handle.
 		plugins_url( '/dist/blocks.build.js', dirname( __FILE__ ) ), // Block.build.js: We register the block here. Built with Webpack.
-		array( 'wp-blocks', 'wp-i18n', 'wp-element' ), // Dependencies, defined above.
+		array( 'wp-blocks', 'wp-editor', 'wp-i18n', 'wp-element' ), // Dependencies, defined above.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.build.js' ), // Version: filemtime — Gets file modification time.
 		true // Enqueue the script in the footer.
 	);


### PR DESCRIPTION
It doesn't seem to work without the `wp-editor` dependency. 